### PR TITLE
💾 Mig to Async Resolvers

### DIFF
--- a/.yarn/versions/96b66340.yml
+++ b/.yarn/versions/96b66340.yml
@@ -1,0 +1,13 @@
+releases:
+  "@iguhealth/admin-app": patch
+  "@iguhealth/cli": patch
+  "@iguhealth/client": patch
+  "@iguhealth/components": patch
+  "@iguhealth/fhir-validation": patch
+  "@iguhealth/fhirpath": patch
+  "@iguhealth/generated-ops": patch
+  "@iguhealth/meta-value": patch
+  "@iguhealth/operation-execution": patch
+  "@iguhealth/server": patch
+  "@iguhealth/testscript-runner": patch
+  "@iguhealth/x-fhir-query": patch

--- a/packages/fhir-validation/src/index.test.ts
+++ b/packages/fhir-validation/src/index.test.ts
@@ -54,17 +54,20 @@ const memDatabase = createMemoryDatabase([
 
 const CTX: ValidationCTX = {
   fhirVersion: R4,
-  resolveTypeToCanonical: (version: FHIR_VERSION, type: uri): canonical => {
+  resolveTypeToCanonical: async (
+    version: FHIR_VERSION,
+    type: uri,
+  ): Promise<canonical> => {
     return `http://hl7.org/fhir/StructureDefinition/${type}` as canonical;
   },
-  resolveCanonical: <
+  resolveCanonical: async <
     Version extends FHIR_VERSION,
     Type extends ResourceType<Version>,
   >(
     version: Version,
     t: Type,
     url: canonical,
-  ): Resource<Version, Type> => {
+  ): Promise<Resource<Version, Type>> => {
     // @ts-ignore
     const sd: Resource<Version, Type> = memDatabase[t].find(
       (sd: unknown) => (sd as StructureDefinition).url === url,

--- a/packages/fhir-validation/src/index.ts
+++ b/packages/fhir-validation/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { eleIndexToChildIndices as eleIndexToChildIndexes } from "@iguhealth/codegen";
 import {
   Loc,
@@ -35,7 +36,7 @@ export interface ValidationCTX {
   resolveTypeToCanonical<Version extends FHIR_VERSION>(
     version: Version,
     type: uri,
-  ): canonical | undefined;
+  ): Promise<canonical | undefined>;
   resolveCanonical: <
     FHIRVersion extends FHIR_VERSION,
     Type extends ResourceType<FHIRVersion>,
@@ -43,7 +44,7 @@ export interface ValidationCTX {
     fhirVersion: FHIRVersion,
     type: Type,
     url: canonical,
-  ) => Resource<FHIRVersion, Type> | undefined;
+  ) => Promise<Resource<FHIRVersion, Type> | undefined>;
   validateCode?(system: string, code: string): Promise<boolean>;
 }
 
@@ -321,7 +322,7 @@ async function validateReferenceTypeConstraint(
   if (referenceProfiles === undefined || referenceProfiles?.length === 0)
     return [];
   for (const profile of referenceProfiles || []) {
-    const sd = ctx.resolveCanonical(
+    const sd = await ctx.resolveCanonical(
       ctx.fhirVersion,
       "StructureDefinition",
       profile,
@@ -686,7 +687,7 @@ export default async function validate(
   if (primitiveTypes.has(type))
     return validatePrimitive(ctx, undefined, root, path, type);
 
-  const canonical = ctx.resolveTypeToCanonical(ctx.fhirVersion, type);
+  const canonical = await ctx.resolveTypeToCanonical(ctx.fhirVersion, type);
   if (!canonical) {
     throw new OperationError(
       outcomeFatal(
@@ -696,7 +697,7 @@ export default async function validate(
       ),
     );
   }
-  const sd = ctx.resolveCanonical(
+  const sd = await ctx.resolveCanonical(
     ctx.fhirVersion,
     "StructureDefinition",
     canonical,

--- a/packages/generated-ops/src/r4/ops.test.ts
+++ b/packages/generated-ops/src/r4/ops.test.ts
@@ -28,19 +28,22 @@ const sds = loadArtifacts({
 
 test("Test ValueSet Expands", async () => {
   const ctx: OpCTX = {
-    resolveCanonical<
+    async resolveCanonical<
       FHIRVersion extends FHIR_VERSION,
       Type extends ResourceType<FHIRVersion>,
     >(
       fhirVersion: FHIRVersion,
       type: Type,
       url: canonical,
-    ): Resource<FHIRVersion, Type> | undefined {
+    ): Promise<Resource<FHIRVersion, Type> | undefined> {
       const sd = sds.find((sd) => sd.url === url);
       if (!sd) throw new Error(`Could not resolve type ${type}`);
       return sd as Resource<FHIRVersion, Type>;
     },
-    resolveTypeToCanonical(version: FHIR_VERSION, type: uri): canonical {
+    async resolveTypeToCanonical(
+      version: FHIR_VERSION,
+      type: uri,
+    ): Promise<canonical> {
       const sd = sds.find((sd) => sd.type === type);
       if (!sd) throw new Error(`Could not resolve type ${type}`);
       return sd.url as canonical;

--- a/packages/operation-execution/src/index.test.ts
+++ b/packages/operation-execution/src/index.test.ts
@@ -232,19 +232,19 @@ test("execution", async () => {
 
   const ctx: OpCTX = {
     fhirVersion: R4,
-    resolveCanonical<
+    async resolveCanonical<
       FHIRVersion extends FHIR_VERSION,
       Type extends ResourceType<FHIRVersion>,
     >(
       fhirVersion: FHIRVersion,
       type: Type,
       url: canonical,
-    ): Resource<FHIRVersion, Type> | undefined {
+    ): Promise<Resource<FHIRVersion, Type> | undefined> {
       const sd = structureDefinitions.find((sd) => sd.url === url);
       if (!sd) throw new Error(`Could not resolve url ${url}`);
       return sd as Resource<FHIRVersion, Type> | undefined;
     },
-    resolveTypeToCanonical: (version: FHIR_VERSION, type: uri) => {
+    async resolveTypeToCanonical(version: FHIR_VERSION, type: uri) {
       const sd = structureDefinitions.find((sd) => sd.type === type);
       if (!sd) throw new Error(`Could not resolve type ${type}`);
       return sd.url as canonical;

--- a/packages/operation-execution/src/index.test.ts
+++ b/packages/operation-execution/src/index.test.ts
@@ -303,19 +303,19 @@ test("paramValidation", async () => {
 
   const ctx: OpCTX = {
     fhirVersion: R4,
-    resolveCanonical<
+    async resolveCanonical<
       FHIRVersion extends FHIR_VERSION,
       Type extends ResourceType<FHIRVersion>,
     >(
       fhirVersion: FHIRVersion,
       type: Type,
       url: canonical,
-    ): Resource<FHIRVersion, Type> | undefined {
+    ): Promise<Resource<FHIRVersion, Type> | undefined> {
       const sd = structureDefinitions.find((sd) => sd.url === url);
       if (!sd) throw new Error(`Could not resolve url ${url}`);
       return sd as Resource<FHIRVersion, Type> | undefined;
     },
-    resolveTypeToCanonical: (version: FHIR_VERSION, type: uri) => {
+    async resolveTypeToCanonical(version: FHIR_VERSION, type: uri) {
       const sd = structureDefinitions.find((sd) => sd.type === type);
       if (!sd) throw new Error(`Could not resolve type ${type}`);
       return sd.url as canonical;
@@ -513,19 +513,19 @@ test("Test invalid resource validation", async () => {
 
   const ctx: OpCTX = {
     fhirVersion: R4,
-    resolveCanonical<
+    async resolveCanonical<
       FHIRVersion extends FHIR_VERSION,
       Type extends ResourceType<FHIRVersion>,
     >(
       fhirVersion: FHIRVersion,
       type: Type,
       url: canonical,
-    ): Resource<FHIRVersion, Type> | undefined {
+    ): Promise<Resource<FHIRVersion, Type> | undefined> {
       const sd = structureDefinitions.find((sd) => sd.url === url);
       if (!sd) throw new Error(`Could not resolve url ${url}`);
       return sd as Resource<FHIRVersion, Type> | undefined;
     },
-    resolveTypeToCanonical: (version: FHIR_VERSION, type: uri) => {
+    async resolveTypeToCanonical(version: FHIR_VERSION, type: uri) {
       const sd = structureDefinitions.find((sd) => sd.type === type);
       if (!sd) throw new Error(`Could not resolve type ${type}`);
       return sd.url as canonical;

--- a/packages/server/src/fhir-api/types.ts
+++ b/packages/server/src/fhir-api/types.ts
@@ -126,7 +126,8 @@ export interface IGUHealthServerCTX {
   resolveTypeToCanonical: (
     fhirVersion: FHIR_VERSION,
     type: uri,
-  ) => canonical | undefined;
+  ) => Promise<canonical | undefined>;
+
   resolveCanonical: <
     FHIRVersion extends FHIR_VERSION,
     Type extends AllResourceTypes,
@@ -134,7 +135,7 @@ export interface IGUHealthServerCTX {
     fhirVersion: FHIRVersion,
     type: Type,
     url: canonical,
-  ) => Resource<FHIRVersion, Type> | undefined;
+  ) => Promise<Resource<FHIRVersion, Type> | undefined>;
 }
 
 export function rootJWT(tenant: TenantId): AccessTokenPayload<s.user_role> {

--- a/packages/server/src/fhir-operation-executors/providers/local/snapshot.ts
+++ b/packages/server/src/fhir-operation-executors/providers/local/snapshot.ts
@@ -34,11 +34,13 @@ async function generateSnapshot(
   // slice so I'm not altering the original when injecting values with splice.
   const baseSnapshotElements = sd.baseDefinition
     ? (
-        (await ctx.resolveCanonical(
-          fhirVersion,
-          "StructureDefinition",
-          sd.baseDefinition,
-        )?.snapshot?.element) ?? []
+        (
+          await ctx.resolveCanonical(
+            fhirVersion,
+            "StructureDefinition",
+            sd.baseDefinition,
+          )
+        )?.snapshot?.element ?? []
       ).slice()
     : [];
 

--- a/packages/server/src/fhir-storage/providers/memory/async.ts
+++ b/packages/server/src/fhir-storage/providers/memory/async.ts
@@ -404,7 +404,10 @@ function createResolveCanonical(
   const r4Map = createURLMap(data, R4);
   const r4bMap = createURLMap(data, R4B);
 
-  return <FHIRVersion extends FHIR_VERSION, Type extends AllResourceTypes>(
+  return async <
+    FHIRVersion extends FHIR_VERSION,
+    Type extends AllResourceTypes,
+  >(
     fhirVersion: FHIRVersion,
     type: Type,
     url: r4.canonical,
@@ -422,7 +425,7 @@ function createResolveCanonical(
 
 function createResolveTypeToCanonical(
   data: MemoryData,
-): (version: FHIR_VERSION, type: r4.uri) => r4.canonical | undefined {
+): (version: FHIR_VERSION, type: r4.uri) => Promise<r4.canonical | undefined> {
   const r4Map = (
     Object.values(
       data?.[R4]?.["StructureDefinition"] ?? {},
@@ -451,7 +454,7 @@ function createResolveTypeToCanonical(
     new Map(),
   );
 
-  return (version: FHIR_VERSION, type: r4.uri) => {
+  return async (version: FHIR_VERSION, type: r4.uri) => {
     switch (version) {
       case R4: {
         return r4Map.get(type);

--- a/packages/server/src/fhir-storage/providers/memory/search.ts
+++ b/packages/server/src/fhir-storage/providers/memory/search.ts
@@ -65,24 +65,8 @@ async function expressionSearch<CTX extends MemorySearchCTX>(
       meta: {
         fhirVersion,
         type: resource.resourceType as uri,
-        getSD: <Version extends FHIR_VERSION>(
-          fhirVersion: Version,
-          type: uri,
-        ) => {
-          const canonical = ctx.resolveTypeToCanonical(fhirVersion, type);
-          if (!canonical)
-            throw new OperationError(
-              outcomeError(
-                "invalid",
-                `Could not resolve canonical for type '${type}'.`,
-              ),
-            );
-          return ctx.resolveCanonical(
-            fhirVersion,
-            "StructureDefinition",
-            canonical,
-          );
-        },
+        resolveCanonical: ctx.resolveCanonical,
+        resolveTypeToCanonical: ctx.resolveTypeToCanonical,
       },
     },
   );

--- a/packages/server/src/fhir-storage/providers/postgres/index.ts
+++ b/packages/server/src/fhir-storage/providers/postgres/index.ts
@@ -19,7 +19,7 @@ import {
   ResourceType,
 } from "@iguhealth/fhir-types/versions";
 import * as fhirpath from "@iguhealth/fhirpath";
-import { MetaValueSingular } from "@iguhealth/meta-value";
+import { MetaValue } from "@iguhealth/meta-value";
 import {
   isOperationError,
   OperationError,
@@ -106,7 +106,7 @@ async function indexSearchParameter<
     id: id;
     meta: { versionId: id };
   },
-  evaluation: MetaValueSingular<NonNullable<unknown>>[],
+  evaluation: MetaValue<NonNullable<unknown>>[],
 ) {
   switch (parameter.type) {
     case "quantity": {
@@ -611,24 +611,8 @@ async function indexResource<
         {
           meta: {
             fhirVersion,
-            getSD: (fhirVersion, type: uri) => {
-              const canonicalURL = ctx.resolveTypeToCanonical(
-                fhirVersion,
-                type,
-              );
-              if (!canonicalURL)
-                throw new OperationError(
-                  outcomeFatal(
-                    "exception",
-                    `Could not resolve canonical url for type '${type}'`,
-                  ),
-                );
-              return ctx.resolveCanonical(
-                fhirVersion,
-                "StructureDefinition",
-                canonicalURL,
-              );
-            },
+            resolveCanonical: ctx.resolveCanonical,
+            resolveTypeToCanonical: ctx.resolveTypeToCanonical,
           },
         },
       );

--- a/packages/server/src/fhir-storage/test-ctx.ts
+++ b/packages/server/src/fhir-storage/test-ctx.ts
@@ -78,7 +78,7 @@ export const testServices: IGUHealthServerCTX = {
   logger: pino<string>(),
   client: new Memory({ [R4]: {}, [R4B]: {} }),
   cache: new TestCache(),
-  resolveCanonical: <
+  resolveCanonical: async <
     Version extends FHIR_VERSION,
     Type extends AllResourceTypes,
   >(
@@ -88,7 +88,7 @@ export const testServices: IGUHealthServerCTX = {
   ) => {
     return sds.find((sd) => sd.url === url) as Resource<Version, Type>;
   },
-  resolveTypeToCanonical: (_fhirVersion, type: uri) => {
+  resolveTypeToCanonical: async (_fhirVersion, type: uri) => {
     const sd = sds.find((sd) => sd.type === type);
     return sd?.url as canonical;
   },

--- a/packages/server/src/fhir-storage/transactions.ts
+++ b/packages/server/src/fhir-storage/transactions.ts
@@ -55,33 +55,20 @@ export async function buildTransactionTopologicalGraph<
           meta: {
             fhirVersion,
             type: entry.resource.resourceType as uri,
-            getSD: (fhirVersion, type) => {
-              const canonical = ctx.resolveTypeToCanonical(fhirVersion, type);
-              if (!canonical)
-                throw new OperationError(
-                  outcomeFatal(
-                    "exception",
-                    `Could not resolve canonical for type '${type}'.`,
-                  ),
-                );
-              return ctx.resolveCanonical(
-                fhirVersion,
-                "StructureDefinition",
-                canonical,
-              );
-            },
+            resolveCanonical: ctx.resolveCanonical,
+            resolveTypeToCanonical: ctx.resolveTypeToCanonical,
           },
         },
       );
 
       const bundleDependencies = resourceReferences.filter((v) => {
-        const ref = (v.valueOf() as Reference).reference;
+        const ref = (v.getValue() as Reference).reference;
         if (ref && urlToIndice[ref] !== undefined) return true;
         return false;
       });
 
       for (const dep of bundleDependencies) {
-        const ref = (dep.valueOf() as Reference).reference as string;
+        const ref = (dep.getValue() as Reference).reference as string;
         locationsToUpdate[ref] = locationsToUpdate[ref] || [];
         const location = dep.location();
         if (!location)


### PR DESCRIPTION
Move to async resolveCanonical and resolveTypeToCanonical.  This impacts code in meta-value, fhirpath, opdef and validation which rely on using resolver to pull in SD and/or Terminologies.