### PR TITLE
📀 SQL Code Seperation

### DIFF
--- a/.yarn/versions/d2c97d9b.yml
+++ b/.yarn/versions/d2c97d9b.yml
@@ -1,0 +1,2 @@
+releases:
+  "@iguhealth/server": patch

--- a/packages/server/src/fhir-storage/providers/postgres/search/index.ts
+++ b/packages/server/src/fhir-storage/providers/postgres/search/index.ts
@@ -438,9 +438,6 @@ export async function executeSearchQuery<Request extends FHIRSearchRequest>(
 
   return {
     total,
-    resources: resources as Resource<
-      Request["fhirVersion"],
-      AllResourceTypes
-    >[],
+    resources,
   };
 }

--- a/packages/server/src/fhir-storage/providers/postgres/search/index.ts
+++ b/packages/server/src/fhir-storage/providers/postgres/search/index.ts
@@ -387,11 +387,11 @@ export async function executeSearchQuery<Request extends FHIRSearchRequest>(
         ? parseInt(result[0]?.total_count)
         : undefined;
 
-  let resources: Resource<typeof fhirRequest.fhirVersion, AllResourceTypes>[] =
+  let resources: Resource<typeof request.fhirVersion, AllResourceTypes>[] =
     result.map(
       (r) =>
         r.resource as unknown as Resource<
-          typeof fhirRequest.fhirVersion,
+          typeof request.fhirVersion,
           AllResourceTypes
         >,
     );
@@ -406,12 +406,12 @@ export async function executeSearchQuery<Request extends FHIRSearchRequest>(
     resources = resources.concat(
       await processRevInclude(
         ctx,
-        fhirRequest.fhirVersion,
+        request.fhirVersion,
         revIncludeParam,
         result.map(
           (r) =>
             r.resource as unknown as Resource<
-              typeof fhirRequest.fhirVersion,
+              typeof request.fhirVersion,
               AllResourceTypes
             >,
         ),
@@ -423,12 +423,12 @@ export async function executeSearchQuery<Request extends FHIRSearchRequest>(
       await processInclude(
         ctx.db,
         ctx,
-        fhirRequest.fhirVersion,
+        request.fhirVersion,
         includeParam,
         result.map(
           (r) =>
             r.resource as unknown as Resource<
-              typeof fhirRequest.fhirVersion,
+              typeof request.fhirVersion,
               AllResourceTypes
             >,
         ),


### PR DESCRIPTION
Seperating SQL generation from execution of query. Will allow later work to derive filters from Search.