### PR TITLE
✅ Update Create Permission checks with Select Projection

### DIFF
--- a/.yarn/versions/5ffe33e2.yml
+++ b/.yarn/versions/5ffe33e2.yml
@@ -1,0 +1,12 @@
+releases:
+  "@iguhealth/access-control": patch
+  "@iguhealth/admin-app": patch
+  "@iguhealth/cli": patch
+  "@iguhealth/components": patch
+  "@iguhealth/fhirpath": patch
+  "@iguhealth/generated-ops": patch
+  "@iguhealth/meta-value": patch
+  "@iguhealth/server": patch
+  "@iguhealth/smart-launch": patch
+  "@iguhealth/testscript-runner": patch
+  "@iguhealth/x-fhir-query": patch

--- a/packages/server/src/authZ/middleware/scopes.ts
+++ b/packages/server/src/authZ/middleware/scopes.ts
@@ -121,10 +121,13 @@ export function createValidateScopesMiddleware<T>(): MiddlewareAsyncChain<
           // because of existant of the smartScope so pass allong to authorization.
           case "patient": {
             switch (context.request.type) {
+              case "create-request":
+              case "update-request":
               case "delete-request":
               case "search-request":
               case "read-request": {
                 const patientPolicy = await generatePatientScopePolicy(
+                  context.ctx,
                   smartScope,
                   context.request,
                 );
@@ -160,8 +163,6 @@ export function createValidateScopesMiddleware<T>(): MiddlewareAsyncChain<
 
                 return next(context);
               }
-              case "create-request":
-              case "update-request":
               default: {
                 throw new OperationError(
                   outcomeError("forbidden", "Forbidden"),


### PR DESCRIPTION
Modify FP to derive type if resourceType on nonmetavalue. And use a select projection to filter for searchparameters on patient scope perms.