### PR TITLE
Mig to Snapshot + Alteration on Slicing discriminators

### DIFF
--- a/.yarn/versions/cd7630c6.yml
+++ b/.yarn/versions/cd7630c6.yml
@@ -1,0 +1,12 @@
+releases:
+  "@iguhealth/access-control": patch
+  "@iguhealth/admin-app": patch
+  "@iguhealth/cli": patch
+  "@iguhealth/client": patch
+  "@iguhealth/components": patch
+  "@iguhealth/fhir-validation": patch
+  "@iguhealth/generated-ops": patch
+  "@iguhealth/operation-execution": patch
+  "@iguhealth/server": patch
+  "@iguhealth/smart-launch": patch
+  "@iguhealth/testscript-runner": patch

--- a/packages/fhir-validation/src/profile/index.test.ts
+++ b/packages/fhir-validation/src/profile/index.test.ts
@@ -1,0 +1,3 @@
+import { expect, test } from "@jest/globals";
+
+test("Test BP profile", async () => {});

--- a/packages/fhir-validation/src/profile/slicing/index.test.ts
+++ b/packages/fhir-validation/src/profile/slicing/index.test.ts
@@ -94,31 +94,35 @@ const bloodProfile: StructureDefinition = memDatabase[
 ) as StructureDefinition;
 
 test("getSliceIndices", () => {
-  const elements = bloodProfile?.differential?.element ?? [];
+  const elements = bloodProfile?.snapshot?.element ?? [];
   const sliceIndexes = getSliceIndices(elements, 0);
 
   expect(sliceIndexes).toEqual([
     {
-      discriminator: 2,
-      slices: [3, 10],
+      discriminator: 13,
+      slices: [14],
+    },
+    {
+      discriminator: 53,
+      slices: [62, 78],
     },
   ]);
 
-  expect(elements[sliceIndexes[0].discriminator]?.path).toEqual(
+  expect(elements[sliceIndexes[1].discriminator]?.path).toEqual(
     "Observation.component",
   );
 
-  expect(elements[sliceIndexes[0].slices[0]]?.path).toEqual(
+  expect(elements[sliceIndexes[1].slices[0]]?.path).toEqual(
     "Observation.component",
   );
-  expect(elements[sliceIndexes[0].slices[0]]?.id).toEqual(
+  expect(elements[sliceIndexes[1].slices[0]]?.id).toEqual(
     "Observation.component:systolic",
   );
 
-  expect(elements[sliceIndexes[0].slices[1]]?.path).toEqual(
+  expect(elements[sliceIndexes[1].slices[1]]?.path).toEqual(
     "Observation.component",
   );
-  expect(elements[sliceIndexes[0].slices[1]]?.id).toEqual(
+  expect(elements[sliceIndexes[1].slices[1]]?.id).toEqual(
     "Observation.component:diastolic",
   );
 });
@@ -198,7 +202,7 @@ const bloodPressureObservation: Observation = {
 } as Observation;
 
 test("Slice Splitting", async () => {
-  const elements = bloodProfile?.differential?.element ?? [];
+  const elements = bloodProfile?.snapshot?.element ?? [];
   const sliceIndexes = getSliceIndices(elements, 0);
 
   expect(
@@ -222,7 +226,7 @@ test("Slice Splitting", async () => {
   expect(
     bloodPressureObservation?.component?.[1]?.code.coding?.[0]?.code,
   ).toEqual("8462-4");
-  expect(bloodProfile?.differential?.element[3]?.sliceName).toEqual("systolic");
+  expect(bloodProfile?.snapshot?.element[3]?.sliceName).toEqual("systolic");
 });
 
 test("Slice Validation", async () => {
@@ -239,109 +243,109 @@ test("Slice Validation", async () => {
     ),
   ).resolves.toEqual([]);
 
-  // expect(
-  //   validateSliceDescriptor(
-  //     CTX,
-  //     bloodProfile,
-  //     sliceIndexes[0],
-  //     {
-  //       id: "asdf",
-  //       resourceType: "Observation",
-  //       component: [
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //                 code: "8480-6",
-  //               },
-  //             ],
-  //           },
-  //           valueQuantity: {
-  //             value: 109,
-  //             unit: "mmHg",
-  //             system: "http://unitsofmeasure.org",
-  //             code: "mm[Hg]",
-  //           },
-  //         },
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //                 code: "8462-4",
-  //               },
-  //             ],
-  //           },
-  //           valueInteger: 44,
-  //         },
-  //       ],
-  //     },
-  //     pointer("Observation", "asdf" as id),
-  //   ),
-  // ).resolves.toEqual([
-  //   {
-  //     code: "structure",
-  //     diagnostics:
-  //       "Additional fields found at path '/component/1': 'valueInteger'",
-  //     expression: ["/component/1"],
-  //     severity: "error",
-  //   },
-  // ]);
+  expect(
+    validateSliceDescriptor(
+      CTX,
+      bloodProfile,
+      sliceIndexes[0],
+      {
+        id: "asdf",
+        resourceType: "Observation",
+        component: [
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "8480-6",
+                },
+              ],
+            },
+            valueQuantity: {
+              value: 109,
+              unit: "mmHg",
+              system: "http://unitsofmeasure.org",
+              code: "mm[Hg]",
+            },
+          },
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "8462-4",
+                },
+              ],
+            },
+            valueInteger: 44,
+          },
+        ],
+      },
+      pointer("Observation", "asdf" as id),
+    ),
+  ).resolves.toEqual([
+    {
+      code: "structure",
+      diagnostics:
+        "Additional fields found at path '/component/1': 'valueInteger'",
+      expression: ["/component/1"],
+      severity: "error",
+    },
+  ]);
 
-  // expect(
-  //   validateSliceDescriptor(
-  //     CTX,
-  //     bloodProfile,
-  //     sliceIndexes[0],
-  //     {
-  //       id: "asdf",
-  //       resourceType: "Observation",
-  //       component: [
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //                 code: "8480-6",
-  //               },
-  //             ],
-  //           },
-  //           valueQuantity: {
-  //             value: 109,
-  //             unit: "mmHg",
-  //             system: "http://unitsofmeasure.org",
-  //             code: "mm[Hg]",
-  //           },
-  //         },
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //               },
-  //             ],
-  //           },
-  //           valueQuantity: {
-  //             value: 44,
-  //             unit: "mmHg",
-  //             system: "http://unitsofmeasure.org",
-  //             code: "mm[Hg]",
-  //           },
-  //         },
-  //       ],
-  //     },
-  //     pointer("Observation", "asdf" as id),
-  //   ),
-  // ).resolves.toEqual([
-  //   {
-  //     code: "structure",
-  //     diagnostics:
-  //       "Slice 'diastolic' does not have the minimum number of values.",
-  //     expression: undefined,
-  //     severity: "error",
-  //   },
-  // ]);
+  expect(
+    validateSliceDescriptor(
+      CTX,
+      bloodProfile,
+      sliceIndexes[0],
+      {
+        id: "asdf",
+        resourceType: "Observation",
+        component: [
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "8480-6",
+                },
+              ],
+            },
+            valueQuantity: {
+              value: 109,
+              unit: "mmHg",
+              system: "http://unitsofmeasure.org",
+              code: "mm[Hg]",
+            },
+          },
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                },
+              ],
+            },
+            valueQuantity: {
+              value: 44,
+              unit: "mmHg",
+              system: "http://unitsofmeasure.org",
+              code: "mm[Hg]",
+            },
+          },
+        ],
+      },
+      pointer("Observation", "asdf" as id),
+    ),
+  ).resolves.toEqual([
+    {
+      code: "structure",
+      diagnostics:
+        "Slice 'diastolic' does not have the minimum number of values.",
+      expression: undefined,
+      severity: "error",
+    },
+  ]);
 });
 
 test("Pattern Check", async () => {

--- a/packages/fhir-validation/src/profile/slicing/index.test.ts
+++ b/packages/fhir-validation/src/profile/slicing/index.test.ts
@@ -239,109 +239,109 @@ test("Slice Validation", async () => {
     ),
   ).resolves.toEqual([]);
 
-  expect(
-    validateSliceDescriptor(
-      CTX,
-      bloodProfile,
-      sliceIndexes[0],
-      {
-        id: "asdf",
-        resourceType: "Observation",
-        component: [
-          {
-            code: {
-              coding: [
-                {
-                  system: "http://loinc.org",
-                  code: "8480-6",
-                },
-              ],
-            },
-            valueQuantity: {
-              value: 109,
-              unit: "mmHg",
-              system: "http://unitsofmeasure.org",
-              code: "mm[Hg]",
-            },
-          },
-          {
-            code: {
-              coding: [
-                {
-                  system: "http://loinc.org",
-                  code: "8462-4",
-                },
-              ],
-            },
-            valueInteger: 44,
-          },
-        ],
-      },
-      pointer("Observation", "asdf" as id),
-    ),
-  ).resolves.toEqual([
-    {
-      code: "structure",
-      diagnostics:
-        "Additional fields found at path '/component/1': 'valueInteger'",
-      expression: ["/component/1"],
-      severity: "error",
-    },
-  ]);
+  // expect(
+  //   validateSliceDescriptor(
+  //     CTX,
+  //     bloodProfile,
+  //     sliceIndexes[0],
+  //     {
+  //       id: "asdf",
+  //       resourceType: "Observation",
+  //       component: [
+  //         {
+  //           code: {
+  //             coding: [
+  //               {
+  //                 system: "http://loinc.org",
+  //                 code: "8480-6",
+  //               },
+  //             ],
+  //           },
+  //           valueQuantity: {
+  //             value: 109,
+  //             unit: "mmHg",
+  //             system: "http://unitsofmeasure.org",
+  //             code: "mm[Hg]",
+  //           },
+  //         },
+  //         {
+  //           code: {
+  //             coding: [
+  //               {
+  //                 system: "http://loinc.org",
+  //                 code: "8462-4",
+  //               },
+  //             ],
+  //           },
+  //           valueInteger: 44,
+  //         },
+  //       ],
+  //     },
+  //     pointer("Observation", "asdf" as id),
+  //   ),
+  // ).resolves.toEqual([
+  //   {
+  //     code: "structure",
+  //     diagnostics:
+  //       "Additional fields found at path '/component/1': 'valueInteger'",
+  //     expression: ["/component/1"],
+  //     severity: "error",
+  //   },
+  // ]);
 
-  expect(
-    validateSliceDescriptor(
-      CTX,
-      bloodProfile,
-      sliceIndexes[0],
-      {
-        id: "asdf",
-        resourceType: "Observation",
-        component: [
-          {
-            code: {
-              coding: [
-                {
-                  system: "http://loinc.org",
-                  code: "8480-6",
-                },
-              ],
-            },
-            valueQuantity: {
-              value: 109,
-              unit: "mmHg",
-              system: "http://unitsofmeasure.org",
-              code: "mm[Hg]",
-            },
-          },
-          {
-            code: {
-              coding: [
-                {
-                  system: "http://loinc.org",
-                },
-              ],
-            },
-            valueQuantity: {
-              value: 44,
-              unit: "mmHg",
-              system: "http://unitsofmeasure.org",
-              code: "mm[Hg]",
-            },
-          },
-        ],
-      },
-      pointer("Observation", "asdf" as id),
-    ),
-  ).resolves.toEqual([
-    {
-      code: "structure",
-      diagnostics:
-        "Slice 'diastolic' does not have the minimum number of values.",
-      expression: undefined,
-      severity: "error",
-    },
-  ]);
+  // expect(
+  //   validateSliceDescriptor(
+  //     CTX,
+  //     bloodProfile,
+  //     sliceIndexes[0],
+  //     {
+  //       id: "asdf",
+  //       resourceType: "Observation",
+  //       component: [
+  //         {
+  //           code: {
+  //             coding: [
+  //               {
+  //                 system: "http://loinc.org",
+  //                 code: "8480-6",
+  //               },
+  //             ],
+  //           },
+  //           valueQuantity: {
+  //             value: 109,
+  //             unit: "mmHg",
+  //             system: "http://unitsofmeasure.org",
+  //             code: "mm[Hg]",
+  //           },
+  //         },
+  //         {
+  //           code: {
+  //             coding: [
+  //               {
+  //                 system: "http://loinc.org",
+  //               },
+  //             ],
+  //           },
+  //           valueQuantity: {
+  //             value: 44,
+  //             unit: "mmHg",
+  //             system: "http://unitsofmeasure.org",
+  //             code: "mm[Hg]",
+  //           },
+  //         },
+  //       ],
+  //     },
+  //     pointer("Observation", "asdf" as id),
+  //   ),
+  // ).resolves.toEqual([
+  //   {
+  //     code: "structure",
+  //     diagnostics:
+  //       "Slice 'diastolic' does not have the minimum number of values.",
+  //     expression: undefined,
+  //     severity: "error",
+  //   },
+  // ]);
 });
 
 test("Pattern Check", async () => {

--- a/packages/fhir-validation/src/profile/slicing/index.test.ts
+++ b/packages/fhir-validation/src/profile/slicing/index.test.ts
@@ -239,109 +239,109 @@ test("Slice Validation", async () => {
     ),
   ).resolves.toEqual([]);
 
-  // expect(
-  //   validateSliceDescriptor(
-  //     CTX,
-  //     bloodProfile,
-  //     sliceIndexes[0],
-  //     {
-  //       id: "asdf",
-  //       resourceType: "Observation",
-  //       component: [
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //                 code: "8480-6",
-  //               },
-  //             ],
-  //           },
-  //           valueQuantity: {
-  //             value: 109,
-  //             unit: "mmHg",
-  //             system: "http://unitsofmeasure.org",
-  //             code: "mm[Hg]",
-  //           },
-  //         },
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //                 code: "8462-4",
-  //               },
-  //             ],
-  //           },
-  //           valueInteger: 44,
-  //         },
-  //       ],
-  //     },
-  //     pointer("Observation", "asdf" as id),
-  //   ),
-  // ).resolves.toEqual([
-  //   {
-  //     code: "structure",
-  //     diagnostics:
-  //       "Additional fields found at path '/component/1': 'valueInteger'",
-  //     expression: ["/component/1"],
-  //     severity: "error",
-  //   },
-  // ]);
+  expect(
+    validateSliceDescriptor(
+      CTX,
+      bloodProfile,
+      sliceIndexes[0],
+      {
+        id: "asdf",
+        resourceType: "Observation",
+        component: [
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "8480-6",
+                },
+              ],
+            },
+            valueQuantity: {
+              value: 109,
+              unit: "mmHg",
+              system: "http://unitsofmeasure.org",
+              code: "mm[Hg]",
+            },
+          },
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "8462-4",
+                },
+              ],
+            },
+            valueInteger: 44,
+          },
+        ],
+      },
+      pointer("Observation", "asdf" as id),
+    ),
+  ).resolves.toEqual([
+    {
+      code: "structure",
+      diagnostics:
+        "Additional fields found at path '/component/1': 'valueInteger'",
+      expression: ["/component/1"],
+      severity: "error",
+    },
+  ]);
 
-  // expect(
-  //   validateSliceDescriptor(
-  //     CTX,
-  //     bloodProfile,
-  //     sliceIndexes[0],
-  //     {
-  //       id: "asdf",
-  //       resourceType: "Observation",
-  //       component: [
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //                 code: "8480-6",
-  //               },
-  //             ],
-  //           },
-  //           valueQuantity: {
-  //             value: 109,
-  //             unit: "mmHg",
-  //             system: "http://unitsofmeasure.org",
-  //             code: "mm[Hg]",
-  //           },
-  //         },
-  //         {
-  //           code: {
-  //             coding: [
-  //               {
-  //                 system: "http://loinc.org",
-  //               },
-  //             ],
-  //           },
-  //           valueQuantity: {
-  //             value: 44,
-  //             unit: "mmHg",
-  //             system: "http://unitsofmeasure.org",
-  //             code: "mm[Hg]",
-  //           },
-  //         },
-  //       ],
-  //     },
-  //     pointer("Observation", "asdf" as id),
-  //   ),
-  // ).resolves.toEqual([
-  //   {
-  //     code: "structure",
-  //     diagnostics:
-  //       "Slice 'diastolic' does not have the minimum number of values.",
-  //     expression: undefined,
-  //     severity: "error",
-  //   },
-  // ]);
+  expect(
+    validateSliceDescriptor(
+      CTX,
+      bloodProfile,
+      sliceIndexes[0],
+      {
+        id: "asdf",
+        resourceType: "Observation",
+        component: [
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                  code: "8480-6",
+                },
+              ],
+            },
+            valueQuantity: {
+              value: 109,
+              unit: "mmHg",
+              system: "http://unitsofmeasure.org",
+              code: "mm[Hg]",
+            },
+          },
+          {
+            code: {
+              coding: [
+                {
+                  system: "http://loinc.org",
+                },
+              ],
+            },
+            valueQuantity: {
+              value: 44,
+              unit: "mmHg",
+              system: "http://unitsofmeasure.org",
+              code: "mm[Hg]",
+            },
+          },
+        ],
+      },
+      pointer("Observation", "asdf" as id),
+    ),
+  ).resolves.toEqual([
+    {
+      code: "structure",
+      diagnostics:
+        "Slice 'diastolic' does not have the minimum number of values.",
+      expression: undefined,
+      severity: "error",
+    },
+  ]);
 });
 
 test("Pattern Check", async () => {

--- a/packages/fhir-validation/src/profile/slicing/index.ts
+++ b/packages/fhir-validation/src/profile/slicing/index.ts
@@ -118,7 +118,9 @@ async function isConformantToSlicesDiscriminator(
   switch (discriminator.type) {
     case "value": {
       const expectedValue = (
-        await fp.evaluate("$this.fixed", sliceValueElementDefinition)
+        await fp.evaluate("$this.fixed", sliceValueElementDefinition, {
+          type: "ElementDefinition" as uri,
+        })
       )[0];
       const conformantLocs: Loc<any, any, any>[] = [];
 
@@ -244,32 +246,32 @@ export async function splitSlicing(
     let sliceValueLocs = locsToCheck;
     for (let d = 0; d < discriminators.length; d++) {
       const discriminator = discriminators[d];
-      const sliceElementIndex = findElementDefinitionForSliceDiscriminator(
-        discriminatorElementPaths[d],
-        elements,
-        sliceIndex,
-      );
+      const sliceDiscriminatorElementIndex =
+        findElementDefinitionForSliceDiscriminator(
+          discriminatorElementPaths[d],
+          elements,
+          sliceIndex,
+        );
 
-      if (!sliceElementIndex)
+      if (!sliceDiscriminatorElementIndex)
         throw new OperationError(
           outcomeError(
             "invalid",
-            "could not find element definition for slice",
+            "could not find element definition to use for slice discriminator.",
           ),
         );
 
-      const sliceElement = elements[sliceElementIndex];
+      const sliceElement = elements[sliceDiscriminatorElementIndex];
 
       sliceValueLocs = await isConformantToSlicesDiscriminator(
         discriminator,
         sliceElement,
         root,
-        locsToCheck,
+        sliceValueLocs,
       );
     }
 
     locsToCheck = locsToCheck.filter((l) => !sliceValueLocs.includes(l));
-
     sliceSplit[sliceIndex] = sliceValueLocs;
   }
 

--- a/packages/server/src/fhir-operation-executors/providers/local/ops/snapshot.ts
+++ b/packages/server/src/fhir-operation-executors/providers/local/ops/snapshot.ts
@@ -24,7 +24,7 @@ async function generateSnapshot(
 ): Promise<StructureDefinition> {
   if (sd.snapshot) return sd as StructureDefinition;
 
-  if (!sd.differential)
+  if (!sd.snapshot)
     throw new OperationError(
       outcomeError(
         "invalid",
@@ -44,7 +44,7 @@ async function generateSnapshot(
       ).slice()
     : [];
 
-  for (const element of sd.differential.element) {
+  for (const element of sd.snapshot.element) {
     const existingElementIndex = findLastIndex(
       baseSnapshotElements,
       (e) => e.id === element.id,

--- a/packages/server/src/fhir-operation-executors/providers/local/ops/snapshot.ts
+++ b/packages/server/src/fhir-operation-executors/providers/local/ops/snapshot.ts
@@ -24,7 +24,7 @@ async function generateSnapshot(
 ): Promise<StructureDefinition> {
   if (sd.snapshot) return sd as StructureDefinition;
 
-  if (!sd.snapshot)
+  if (!sd.differential)
     throw new OperationError(
       outcomeError(
         "invalid",
@@ -44,7 +44,7 @@ async function generateSnapshot(
       ).slice()
     : [];
 
-  for (const element of sd.snapshot.element) {
+  for (const element of sd.differential.element) {
     const existingElementIndex = findLastIndex(
       baseSnapshotElements,
       (e) => e.id === element.id,


### PR DESCRIPTION
Slicing alteration on discriminator to properly filter + migration to use snapshot instead of diff (may use diff for optimization but seems as though they are not properly maintained IE us-core BloodPressure Profile does not have on differential the Observation.category slice.