### PR TITLE
Uniqueness at type level

### DIFF
--- a/.yarn/versions/6aa15359.yml
+++ b/.yarn/versions/6aa15359.yml
@@ -1,0 +1,2 @@
+releases:
+  "@iguhealth/server": patch

--- a/packages/server/src/authN/middleware.ts
+++ b/packages/server/src/authN/middleware.ts
@@ -153,7 +153,7 @@ async function findResourceAndAccessPolicies<
     };
 
   const [member, accessPolicies] = await Promise.all([
-    ctx.store.readLatestResourceById(asRoot(ctx), R4, memberId),
+    ctx.store.readLatestResourceById(asRoot(ctx), R4, "Membership", memberId),
     ctx.store.readResourcesByVersionId(asRoot(ctx), R4, accessPolicyVersionIds),
   ]);
 

--- a/packages/server/src/authN/middleware.ts
+++ b/packages/server/src/authN/middleware.ts
@@ -153,7 +153,7 @@ async function findResourceAndAccessPolicies<
     };
 
   const [member, accessPolicies] = await Promise.all([
-    ctx.store.readLatestResourceById(asRoot(ctx), R4, "Membership", memberId),
+    ctx.store.readLatestResourceById(asRoot(ctx), R4, memberType, memberId),
     ctx.store.readResourcesByVersionId(asRoot(ctx), R4, accessPolicyVersionIds),
   ]);
 

--- a/packages/server/src/authN/oidc/routes/interactions/password-reset.ts
+++ b/packages/server/src/authN/oidc/routes/interactions/password-reset.ts
@@ -362,6 +362,7 @@ export function passwordResetInitiatePOST(): OIDCRouteHandler {
     const membership = await ctx.state.iguhealth.store.readLatestResourceById(
       ctx.state.iguhealth,
       R4,
+      "Membership",
       user.fhir_user_id as id,
     );
 

--- a/packages/server/src/authN/oidc/routes/interactions/signup.ts
+++ b/packages/server/src/authN/oidc/routes/interactions/signup.ts
@@ -60,6 +60,7 @@ export const signupPOST = (): OIDCRouteHandler => async (ctx) => {
     const membership = await ctx.state.iguhealth.store.readLatestResourceById(
       asRoot(ctx.state.iguhealth),
       R4,
+      "Membership",
       existingUser.fhir_user_id as id,
     );
     if (!membership || membership.resourceType !== "Membership") {

--- a/packages/server/src/fhir-operation-executors/providers/local/ops/password-reset.ts
+++ b/packages/server/src/fhir-operation-executors/providers/local/ops/password-reset.ts
@@ -144,6 +144,7 @@ export const IguhealthPasswordResetInvoke = InlineOperation(
     const membership = await ctx.store.readLatestResourceById(
       ctx,
       R4,
+      "Membership",
       request.id,
     );
 

--- a/packages/server/src/resource-stores/interface.ts
+++ b/packages/server/src/resource-stores/interface.ts
@@ -10,6 +10,7 @@ import {
   AllResourceTypes,
   FHIR_VERSION,
   Resource,
+  ResourceType,
 } from "@iguhealth/fhir-types/versions";
 
 export type Insertable = Extract<s.Table, "users" | "resources" | "tenants">;
@@ -27,11 +28,15 @@ export interface ResourceStore<CTX> {
     version_ids: id[],
   ): Promise<Resource<Version, AllResourceTypes>[]>;
 
-  readLatestResourceById<Version extends FHIR_VERSION>(
+  readLatestResourceById<
+    Version extends FHIR_VERSION,
+    Type extends ResourceType<Version>,
+  >(
     ctx: CTX,
     fhirVersion: Version,
+    type: Type,
     id: id,
-  ): Promise<Resource<Version, AllResourceTypes> | undefined>;
+  ): Promise<Resource<Version, Type> | undefined>;
 
   history<Version extends FHIR_VERSION>(
     ctx: CTX,

--- a/packages/server/src/resource-stores/postgres/index.ts
+++ b/packages/server/src/resource-stores/postgres/index.ts
@@ -6,6 +6,7 @@ import {
   AllResourceTypes,
   FHIR_VERSION,
   Resource,
+  ResourceType,
 } from "@iguhealth/fhir-types/versions";
 import { OperationError, outcomeError } from "@iguhealth/operation-outcomes";
 import {
@@ -197,17 +198,19 @@ export class PostgresStore<CTX extends Pick<IGUHealthServerCTX, "tenant">>
     return returnOrdered.filter((r) => r !== undefined);
   }
 
-  async readLatestResourceById<Version extends FHIR_VERSION>(
+  async readLatestResourceById<Version extends FHIR_VERSION, Type extends ResourceType<Version>>(
     ctx: CTX,
     fhirVersion: Version,
+    resourceType: Type,
     id: id,
-  ): Promise<Resource<Version, AllResourceTypes> | undefined> {
+  ): Promise<Resource<Version, Type> | undefined> {
     const result = await db
       .selectOne(
         "resources",
         {
           tenant: ctx.tenant,
           id: id,
+          resource_type: resourceType,
           fhir_version: toDBFHIRVersion(fhirVersion),
         },
         {
@@ -218,7 +221,7 @@ export class PostgresStore<CTX extends Pick<IGUHealthServerCTX, "tenant">>
       .run(this.getClient());
 
     return result?.resource as unknown as Promise<
-      Resource<Version, AllResourceTypes> | undefined
+      Resource<Version, Type> | undefined
     >;
   }
 

--- a/packages/server/testscripts/r4/update-client-supplied-id.testscript.json
+++ b/packages/server/testscripts/r4/update-client-supplied-id.testscript.json
@@ -98,13 +98,7 @@
         },
         {
           "assert": {
-            "resource": "OperationOutcome"
-          }
-        },
-        {
-          "assert": {
-            "expression": "OperationOutcome.issue[0].code",
-            "value": "invalid"
+            "resource": "Encounter"
           }
         },
         {

--- a/packages/server/testscripts/r4b/update-client-supplied-id.testscript.json
+++ b/packages/server/testscripts/r4b/update-client-supplied-id.testscript.json
@@ -98,13 +98,7 @@
         },
         {
           "assert": {
-            "resource": "OperationOutcome"
-          }
-        },
-        {
-          "assert": {
-            "expression": "OperationOutcome.issue[0].code",
-            "value": "invalid"
+            "resource": "Encounter"
           }
         },
         {


### PR DESCRIPTION
Uniqueness of IDs should only be enforced on the type level. This change enforces that. Related to syncing artifacts which may have overlap of ids.